### PR TITLE
feat - trash and archive page

### DIFF
--- a/src/components/LabelsDialog.jsx
+++ b/src/components/LabelsDialog.jsx
@@ -68,7 +68,7 @@ export function LabelsDialog({ note, editMode, setNote }) {
 
   function updateLabelsList(selectedNote, value) {
     if (filteredLabels.length > 0) {
-      showSnackbar(`${value} label already exists!`);
+      showSnackbar(`"${value}" label already exists!`);
     } else {
       if (editMode) {
         // update note labels - edit/add note page

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -35,6 +35,7 @@ export function Navbar() {
       ) && (
         <div className="navbar-action">
           <button
+            title={gridView ? "List view" : "Grid view"}
             className="btn-icon btn-outline-primary material-icons-outlined view-toggle-icon"
             onClick={() => setGridView((value) => !value)}
           >
@@ -42,6 +43,7 @@ export function Navbar() {
           </button>
           {authToken ? (
             <button
+              title="Logout"
               className="link btn-icon btn-outline-primary material-icons"
               onClick={logout}
             >
@@ -49,6 +51,7 @@ export function Navbar() {
             </button>
           ) : (
             <Link
+              title="Login"
               to="/login"
               className="link btn-icon btn-outline-primary material-icons"
             >

--- a/src/components/Note.jsx
+++ b/src/components/Note.jsx
@@ -1,0 +1,187 @@
+import { useState } from "react";
+import { useDBdata } from "../context/db-data-context";
+import { useMessageHandling } from "../context/message-handling-context";
+import { v4 as uuid } from "uuid";
+import { bgColorPalette } from "../utilities/bg-color-palette";
+import { LabelsDialog } from "./LabelsDialog";
+import { useLocation, useNavigate } from "react-router-dom";
+
+export function Note({ note }) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { gridView } = useMessageHandling();
+  const { notes, updateNote } = useDBdata();
+  // to store data for which note(index), the color palette is open/close
+  const [showColorPalette, setShowColorPalette] = useState(false);
+  const [showLabelsDialog, setShowLabelsDialog] = useState(false);
+  function updateNoteStatus(type, msg) {
+    updateNote(
+      notes.map((element) =>
+        element.id === note.id
+          ? { ...note, [type]: !note[type], updatedOn: new Date() }
+          : element
+      ),
+      `Note ${msg} ${type}!`,
+      false
+    );
+  }
+
+  function duplicateNote() {
+    updateNote(
+      [
+        ...notes,
+        { ...note, id: uuid(), updatedOn: new Date(), createdOn: new Date() },
+      ],
+      "Duplicate note created!",
+      true
+    );
+  }
+
+  function changeNoteBgColor(color) {
+    updateNote(
+      notes.map((element) =>
+        element.id === note.id ? { ...note, bgColor: color } : element
+      ),
+      "Note background changed!",
+      false
+    );
+  }
+
+  function openNote() {
+    navigate(`${location.pathname}/note/${note.id}`, {
+      state: { background: location, note },
+    });
+  }
+
+  function removeLabel(selectedLabel) {
+    const dataToSend = notes.map((element) =>
+      element.id === note.id
+        ? {
+            ...element,
+            labels: element.labels.filter((item) => item !== selectedLabel),
+          }
+        : element
+    );
+    const msg = `"${selectedLabel}" label removed from the note!`;
+    updateNote(dataToSend, msg, false);
+  }
+
+  function deleteNote(selectedNote) {
+    updateNote(
+      notes.filter((item) => item.id !== selectedNote.id),
+      "Note deleted forever!",
+      false
+    );
+  }
+
+  return (
+    <div
+      className={`note grid-item card card-basic ${
+        gridView ? "col-1" : "col-3"
+      } col-sm-3 bg-${note.bgColor}`}
+    >
+      <div className="card-header" onClick={() => openNote()}>
+        <div className="card-title note-title py-1">{note.title}</div>
+      </div>
+      <div className="card-content note-content" onClick={() => openNote()}>
+        {note.description}
+      </div>
+
+      <div className="card-footer note-footer">
+        <div className="label-tags pt-2">
+          {note.labels.map((item, i) => (
+            <div key={i} className="label-tag-item">
+              {item}
+              <button
+                className="btn-link btn-sm material-icons"
+                onClick={() => removeLabel(item)}
+              >
+                close
+              </button>
+            </div>
+          ))}
+        </div>
+        {location.pathname === "/notes/trash" ? (
+          <div className="action-icons">
+            <button
+              className="btn-icon material-icons-outlined"
+              onClick={() => updateNoteStatus("trash", "restored from")}
+            >
+              restore_from_trash
+            </button>
+            <button
+              className="btn-icon material-icons-outlined"
+              onClick={() => deleteNote(note)}
+            >
+              delete_forever
+            </button>
+          </div>
+        ) : (
+          <div className="action-icons">
+            <button
+              className="btn-icon material-icons-outlined"
+              onClick={() => {
+                setShowLabelsDialog((value) => !value);
+              }}
+            >
+              new_label
+            </button>
+            {showLabelsDialog && <LabelsDialog note={note} editMode={false} />}
+            <button
+              className="btn-icon material-icons-outlined"
+              onClick={() => setShowColorPalette((value) => !value)}
+            >
+              color_lens
+            </button>
+            {showColorPalette && (
+              <div className="bg-color-palette">
+                <ul className="bg-color-list">
+                  {bgColorPalette.map((item) => (
+                    <li
+                      key={item.id}
+                      className={`avatar avatar-icon avatar-xs bg-${item.bgColor}`}
+                      onClick={() => changeNoteBgColor(item.bgColor)}
+                    >
+                      {item.bgColor === note.bgColor && (
+                        <i className="material-icons">check</i>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <button
+              className="btn-icon material-icons-outlined"
+              onClick={() => duplicateNote()}
+            >
+              content_copy
+            </button>
+
+            {note.archive && (
+              <button
+                className="btn-icon material-icons-outlined"
+                onClick={() => updateNoteStatus("archive", "restored from")}
+              >
+                unarchive
+              </button>
+            )}
+            {!note.archive && (
+              <button
+                className="btn-icon material-icons-outlined"
+                onClick={() => updateNoteStatus("archive", "sent to")}
+              >
+                archive
+              </button>
+            )}
+            <button
+              className="btn-icon material-icons-outlined"
+              onClick={() => updateNoteStatus("trash", "sent to")}
+            >
+              delete
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Note.jsx
+++ b/src/components/Note.jsx
@@ -69,7 +69,7 @@ export function Note({ note }) {
   function deleteNote(selectedNote) {
     updateNote(
       notes.filter((item) => item.id !== selectedNote.id),
-      "Note deleted forever!",
+      "Note permanently deleted!",
       false
     );
   }
@@ -104,12 +104,14 @@ export function Note({ note }) {
         {location.pathname === "/notes/trash" ? (
           <div className="action-icons">
             <button
+              title="Restore"
               className="btn-icon material-icons-outlined"
               onClick={() => updateNoteStatus("trash", "restored from")}
             >
               restore_from_trash
             </button>
             <button
+              title="Delete permanently"
               className="btn-icon material-icons-outlined"
               onClick={() => deleteNote(note)}
             >
@@ -119,6 +121,7 @@ export function Note({ note }) {
         ) : (
           <div className="action-icons">
             <button
+              title="New label"
               className="btn-icon material-icons-outlined"
               onClick={() => {
                 setShowLabelsDialog((value) => !value);
@@ -128,6 +131,7 @@ export function Note({ note }) {
             </button>
             {showLabelsDialog && <LabelsDialog note={note} editMode={false} />}
             <button
+              title="Change card color"
               className="btn-icon material-icons-outlined"
               onClick={() => setShowColorPalette((value) => !value)}
             >
@@ -152,6 +156,7 @@ export function Note({ note }) {
             )}
             <button
               className="btn-icon material-icons-outlined"
+              title="Duplicate"
               onClick={() => duplicateNote()}
             >
               content_copy
@@ -159,6 +164,7 @@ export function Note({ note }) {
 
             {note.archive && (
               <button
+                title="Unarchive"
                 className="btn-icon material-icons-outlined"
                 onClick={() => updateNoteStatus("archive", "restored from")}
               >
@@ -167,6 +173,7 @@ export function Note({ note }) {
             )}
             {!note.archive && (
               <button
+                title="Archive"
                 className="btn-icon material-icons-outlined"
                 onClick={() => updateNoteStatus("archive", "sent to")}
               >
@@ -174,6 +181,7 @@ export function Note({ note }) {
               </button>
             )}
             <button
+              title="Trash"
               className="btn-icon material-icons-outlined"
               onClick={() => updateNoteStatus("trash", "sent to")}
             >

--- a/src/components/NoteFooterIcons.jsx
+++ b/src/components/NoteFooterIcons.jsx
@@ -46,7 +46,7 @@ export function NoteFooterIcons({ note, setNote, id }) {
   function deleteNote(selectedNote) {
     updateNote(
       notes.filter((item) => selectedNote.id !== item.id),
-      "Note deleted forever!",
+      "Note permanently deleted!",
       true
     );
   }

--- a/src/components/NoteFooterIcons.jsx
+++ b/src/components/NoteFooterIcons.jsx
@@ -58,11 +58,13 @@ export function NoteFooterIcons({ note, setNote, id }) {
     <div className="note-action-icons">
       <button
         className="btn-icon material-icons-outlined"
+        title="Restore"
         onClick={() => updateNoteStatus(note, "trash", "restored from")}
       >
         restore_from_trash
       </button>
       <button
+        title="Delete permanently"
         className="btn-icon material-icons-outlined"
         onClick={() => deleteNote(note)}
       >
@@ -72,6 +74,7 @@ export function NoteFooterIcons({ note, setNote, id }) {
   ) : (
     <div className="note-action-icons">
       <button
+        title="New label"
         className="btn-icon material-icons-outlined"
         onClick={() => setShowLabelsDialog((value) => !value)}
       >
@@ -81,6 +84,7 @@ export function NoteFooterIcons({ note, setNote, id }) {
         <LabelsDialog note={note} editMode={true} setNote={setNote} />
       )}
       <button
+        title="Change card color"
         className="btn-icon material-icons-outlined"
         onClick={() => setShowColorPalette((value) => !value)}
       >
@@ -105,6 +109,7 @@ export function NoteFooterIcons({ note, setNote, id }) {
       )}
       <button
         className="btn-icon material-icons-outlined"
+        title="Duplicate"
         disabled={!id}
         onClick={() => duplicateNote(note)}
       >
@@ -112,6 +117,7 @@ export function NoteFooterIcons({ note, setNote, id }) {
       </button>
       {note.archive && (
         <button
+          title="Unarchive"
           className="btn-icon material-icons-outlined"
           disabled={!id}
           onClick={() => updateNoteStatus(note, "archive", "restored from")}
@@ -121,6 +127,7 @@ export function NoteFooterIcons({ note, setNote, id }) {
       )}
       {!note.archive && (
         <button
+          title="Archive"
           className="btn-icon material-icons-outlined"
           disabled={!id}
           onClick={() => updateNoteStatus(note, "archive", "sent to")}
@@ -129,6 +136,7 @@ export function NoteFooterIcons({ note, setNote, id }) {
         </button>
       )}
       <button
+        title="Trash"
         className="btn-icon material-icons-outlined"
         disabled={!id}
         onClick={() => updateNoteStatus(note, "trash", "sent to")}

--- a/src/components/NoteFooterIcons.jsx
+++ b/src/components/NoteFooterIcons.jsx
@@ -1,0 +1,140 @@
+import { useState } from "react";
+import { useDBdata } from "../context/db-data-context";
+import { bgColorPalette } from "../utilities/bg-color-palette";
+import { LabelsDialog } from "./LabelsDialog";
+import { v4 as uuid } from "uuid";
+import { useLocation } from "react-router-dom";
+
+export function NoteFooterIcons({ note, setNote, id }) {
+  const location = useLocation();
+  const [showColorPalette, setShowColorPalette] = useState(false);
+  const [showLabelsDialog, setShowLabelsDialog] = useState(false);
+  const { updateNote, notes } = useDBdata();
+
+  function updateNoteStatus(selectedNote, type, msg) {
+    updateNote(
+      notes.map((element) =>
+        element.id === selectedNote.id
+          ? {
+              ...selectedNote,
+              [type]: !selectedNote[type],
+              updatedOn: new Date(),
+            }
+          : element
+      ),
+      `Note ${msg} ${type}!`,
+      true
+    );
+  }
+
+  function duplicateNote(selectedNote) {
+    updateNote(
+      [
+        ...notes,
+        {
+          ...selectedNote,
+          id: uuid(),
+          updatedOn: new Date(),
+          createdOn: new Date(),
+        },
+      ],
+      "Duplicate note created!",
+      true
+    );
+  }
+
+  function deleteNote(selectedNote) {
+    updateNote(
+      notes.filter((item) => selectedNote.id !== item.id),
+      "Note deleted forever!",
+      true
+    );
+  }
+
+  function changeNoteBgColor(color) {
+    setNote((value) => ({ ...value, bgColor: color }));
+  }
+  return location.pathname.includes("notes/trash") ? (
+    <div className="note-action-icons">
+      <button
+        className="btn-icon material-icons-outlined"
+        onClick={() => updateNoteStatus(note, "trash", "restored from")}
+      >
+        restore_from_trash
+      </button>
+      <button
+        className="btn-icon material-icons-outlined"
+        onClick={() => deleteNote(note)}
+      >
+        delete_forever
+      </button>
+    </div>
+  ) : (
+    <div className="note-action-icons">
+      <button
+        className="btn-icon material-icons-outlined"
+        onClick={() => setShowLabelsDialog((value) => !value)}
+      >
+        new_label
+      </button>
+      {showLabelsDialog && (
+        <LabelsDialog note={note} editMode={true} setNote={setNote} />
+      )}
+      <button
+        className="btn-icon material-icons-outlined"
+        onClick={() => setShowColorPalette((value) => !value)}
+      >
+        color_lens
+      </button>
+      {showColorPalette && (
+        <div className="bg-color-palette">
+          <ul className="bg-color-list">
+            {bgColorPalette.map((item) => (
+              <li
+                key={item.id}
+                className={`avatar avatar-icon avatar-xs bg-${item.bgColor}`}
+                onClick={() => changeNoteBgColor(item.bgColor)}
+              >
+                {item.bgColor === note.bgColor && (
+                  <i className="material-icons">check</i>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <button
+        className="btn-icon material-icons-outlined"
+        disabled={!id}
+        onClick={() => duplicateNote(note)}
+      >
+        content_copy
+      </button>
+      {note.archive && (
+        <button
+          className="btn-icon material-icons-outlined"
+          disabled={!id}
+          onClick={() => updateNoteStatus(note, "archive", "restored from")}
+        >
+          unarchive
+        </button>
+      )}
+      {!note.archive && (
+        <button
+          className="btn-icon material-icons-outlined"
+          disabled={!id}
+          onClick={() => updateNoteStatus(note, "archive", "sent to")}
+        >
+          archive
+        </button>
+      )}
+      <button
+        className="btn-icon material-icons-outlined"
+        disabled={!id}
+        onClick={() => updateNoteStatus(note, "trash", "sent to")}
+      >
+        delete
+      </button>
+    </div>
+  );
+}

--- a/src/components/ZeroNotesPage.jsx
+++ b/src/components/ZeroNotesPage.jsx
@@ -1,0 +1,35 @@
+import { useLocation, useNavigate } from "react-router-dom";
+
+export function ZeroNotesPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  let message = "";
+  let icon = "";
+  let redirectTo = "";
+  if (location.pathname.includes("trash")) {
+    message = "No notes in trash";
+    icon = "delete";
+  } else if (location.pathname.includes("archive")) {
+    message = "No notes in archive";
+    icon = "archive";
+  } else {
+    message = "Start adding notes";
+    icon = "note_add";
+    redirectTo = `${location.pathname}/note`;
+  }
+  return (
+    <div className="my-5 txt-center txt-gray">
+      <button
+        onClick={() =>
+          navigate(redirectTo ?? location.pathname, {
+            state: { background: location },
+          })
+        }
+        className="btn-link h1 material-icons-outlined"
+      >
+        {icon}
+      </button>
+      <h1 className="heading h2">{message}</h1>
+    </div>
+  );
+}

--- a/src/context/db-data-context.jsx
+++ b/src/context/db-data-context.jsx
@@ -1,11 +1,12 @@
 import { createContext, useContext, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { addUserNote, getUserNotes } from "../utilities/server-request";
 import { useMessageHandling } from "./message-handling-context";
 const DBdataContext = createContext();
 
 function DBdataProvider({ children }) {
   const navigate = useNavigate();
+  const location = useLocation();
   const [notes, setNotes] = useState(null);
   const [labels, setLabels] = useState(null);
   const [notesLoading, setNotesLoading] = useState(false);
@@ -41,7 +42,7 @@ function DBdataProvider({ children }) {
       showSnackbar(msg);
       setNotes(notesList);
       if (closeNote) {
-        navigate("/notes");
+        navigate(location?.state?.background?.pathname ?? "/notes");
       }
     } catch (err) {
       showSnackbar("Some error occurred. Try Again!");

--- a/src/pages/Notes.jsx
+++ b/src/pages/Notes.jsx
@@ -32,16 +32,34 @@ export function Notes() {
           <Routes location={background || location}>
             <Route path="/" element={<ViewNotes sortBy={sortBy} />}></Route>
             <Route
+              path="/archive"
+              element={<ViewNotes sortBy={sortBy} />}
+            ></Route>
+            <Route
+              path="/trash"
+              element={<ViewNotes sortBy={sortBy} />}
+            ></Route>
+            <Route
               path="/label/:label"
               element={<ViewNotes sortBy={sortBy} />}
             ></Route>
             <Route path="/note" element={<AddNote />}></Route>
             <Route path="/note/:id" element={<AddNote />}></Route>
+            <Route path="/archive/note/:id" element={<AddNote />}></Route>
+            <Route path="/trash/note/:id" element={<AddNote />}></Route>
+            <Route path="/label/:label/note/:id" element={<AddNote />}></Route>
             <Route path="*" element={<PageNotFound />} />
           </Routes>
           {background && (
             <Routes>
               <Route path="/note/:id" element={<AddNote />}></Route>
+              <Route path="/archive/note/:id" element={<AddNote />}></Route>
+              <Route path="/trash/note/:id" element={<AddNote />}></Route>
+              <Route
+                path="/label/:label/note/:id"
+                element={<AddNote />}
+              ></Route>
+              <Route path="/label/:label/note" element={<AddNote />}></Route>
               <Route path="/note" element={<AddNote />}></Route>
             </Routes>
           )}

--- a/src/utilities/sidenav-items.js
+++ b/src/utilities/sidenav-items.js
@@ -1,17 +1,17 @@
 export const sidenavItemList = [
-  {
-    title: "Edit Label",
-    iconName: "new_label",
-    route: "/",
-  },
+  // {
+  //   title: "Edit Label",
+  //   iconName: "new_label",
+  //   route: "/",
+  // },
   {
     title: "Archive",
     iconName: "archive",
-    route: "/",
+    route: "/notes/archive",
   },
   {
     title: "Trash",
     iconName: "delete",
-    route: "/",
+    route: "/notes/trash",
   },
 ];


### PR DESCRIPTION
This PR includes the following features and changes:
 - archive page
   - user can unarchive and perform other actions on this page
 - trash page
   - user can restore or permanently delete the note
 - separate component "zero notes page"
 - some basic refactoring
    - moved footer icons in "add note" page to new component
    - moved note card in "view notes page" to a separate component  
    
<img width="960" alt="image" src="https://user-images.githubusercontent.com/64582473/168448970-e5b996b2-4915-4ca2-bd8d-d4788d355de7.png">
<img width="955" alt="image" src="https://user-images.githubusercontent.com/64582473/168448977-dc715f91-3beb-4e20-8fcf-49555e9d1dfe.png">

<img width="960" alt="image" src="https://user-images.githubusercontent.com/64582473/168448956-85fb3e64-389e-413e-a54e-0043de72e625.png">
